### PR TITLE
Refactor: add blocks schema in clean-schema-attributes.js

### DIFF
--- a/server/services/helpers/utils/clean-schema-attributes.js
+++ b/server/services/helpers/utils/clean-schema-attributes.js
@@ -84,7 +84,8 @@ const cleanSchemaAttributes = (
         attributesCopy[prop] = { type: 'string', pattern: '^\\d*$', example: '123456789' };
         break;
       }
-      case 'json': {
+      case 'json':
+      case 'blocks': {
         attributesCopy[prop] = {};
         break;
       }
@@ -201,7 +202,9 @@ const cleanSchemaAttributes = (
             properties: {
               data: {
                 type: 'array',
-                items: componentSchemaRefName.length ? { $ref: componentSchemaRefName } : {},
+                items: componentSchemaRefName.length
+                  ? { $ref: `${componentSchemaRefName}ListResponseDataItemLocalized` }
+                  : {},
               },
             },
           };


### PR DESCRIPTION
## Description
I Updated the schema of attributes by adding a new attribute called 'blocks', which will be used in rich text to bring JSON response. This update will also help us to incorporate this rich text (blocks) into our documentation.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?
The way it was tested is update the `node_modules` by replacing the clean-schema-attributes.js with the updated one.

